### PR TITLE
exportTheme

### DIFF
--- a/lib/magicPenPrism.js
+++ b/lib/magicPenPrism.js
@@ -72,15 +72,7 @@ module.exports = {
   name: 'magicpen-prism',
   version: require('../package.json').version,
   installInto: function(magicPen) {
-    Object.keys(defaultTheme).forEach(function(styleName) {
-      var style = defaultTheme[styleName];
-      while (typeof style === 'string' && style in defaultTheme) {
-        style = defaultTheme[style];
-      }
-      magicPen.addStyle(styleName, function(text) {
-        this.text(text, style);
-      });
-    });
+    magicPen.installTheme(defaultTheme);
 
     magicPen.addStyle(
       'code',


### PR DESCRIPTION
This PR reverts the change workaround for the absence of a `.exportTheme()` API.